### PR TITLE
fix load_spikeforest_recording.py

### DIFF
--- a/spikeforest/load_spikeforest_recordings/load_spikeforest_recording.py
+++ b/spikeforest/load_spikeforest_recordings/load_spikeforest_recording.py
@@ -1,9 +1,11 @@
-import kachery_cloud as kcl
 from .load_spikeforest_recordings import load_spikeforest_recordings
+from .load_spikeforest_recordings import default_uri
+from typing import Union
 
-
-def load_spikeforest_recording(*, study_name: str, recording_name: str):
-    all_recordings = load_spikeforest_recordings()
+def load_spikeforest_recording(*, study_name: str, recording_name: str, uri: Union[str, None]):
+    if uri is None:
+        uri = default_uri
+    all_recordings = load_spikeforest_recordings(uri)
     x = [
         R for R in all_recordings
         if R.study_name == study_name and R.recording_name == recording_name


### PR DESCRIPTION
The function `load_spikeforest_recording.py` does not pass through some uri (like 'sha1://43298d72b2d0860ae45fc9b0864137a976cb76e8?hybrid-janelia-spikeforest-recordings.json'):

I modified the function like so:

from .load_spikeforest_recordings import load_spikeforest_recordings
from .load_spikeforest_recordings import default_uri
from typing import Union

def load_spikeforest_recording(*, study_name: str, recording_name: str, uri: Union[str, None]):
    if uri is None:
        uri = default_uri
    all_recordings = load_spikeforest_recordings(uri)
    x = [
        R for R in all_recordings
        if R.study_name == study_name and R.recording_name == recording_name
    ]
    if len(x) == 0: raise Exception(f'Recording not found: {study_name}/{recording_name}')
    R = x[0]
    return R

I tested it out.