### PR TITLE
Fix issue#43 Update minimum required spikeinterface version to 0.100.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
         'kachery-client>=1.2.0',
         'kachery-cloud>=0.1.4',
         'sortingview>=0.7.3',
-        'spikeinterface>=0.93.0'
+        'spikeinterface>=0.100.0'
     ]
 )


### PR DESCRIPTION
This PR updates the minimum required version of spikeinterface to 0.100.0 to resolve the import issue with `write_binary_recording`. This version of spikeinterface includes the restructuring that moved `write_binary_recording` from `core_tools.py` to `recording_tools.py`.

This change addresses the issue described in #43 along with PyPI update to make the pip installed version of MdaRecordingExtractorV2.py matches what is in GitHub.

Changes made:
- Updated setup.py to require spikeinterface>=0.100.0

Testing:
- Tested with spikeinterface 0.100.0 with updated MdaRecordingExtractorV2.py to confirm the import issue is resolved.